### PR TITLE
Use jsonc instead of json for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ All settings can be easily adjusted via the sidebar. Alternatively, you can also
 
 The trigger rules can be configured as follows:
 
-```json
+```jsonc
 "comitto.triggerRules": {
   "fileCountThreshold": 3,     // Number of changed files that trigger a commit
   "specificFiles": [           // Specific files that trigger a commit when changed
@@ -116,7 +116,7 @@ The trigger rules can be configured as follows:
 
 The Git settings can be configured as follows:
 
-```json
+```jsonc
 "comitto.gitSettings": {
   "repositoryPath": "",        // Optional path to the Git repository (defaults to workspace folder)
   "autoPush": false,           // Automatically push after commit


### PR DESCRIPTION
`jsonc` allows for comments in json blocks and won't trigger syntax errors

## Before


![image](https://github.com/user-attachments/assets/3b1f97b8-9001-4267-bd33-31ad0f2cc2e1)

## After

![image](https://github.com/user-attachments/assets/abf8fc2d-3fb3-4bc2-9ae9-4fbd83fe760c)

